### PR TITLE
chore: Use cargo-chef to build the hivetests docker image

### DIFF
--- a/.github/assets/hive/Dockerfile
+++ b/.github/assets/hive/Dockerfile
@@ -1,9 +1,55 @@
-FROM ubuntu
+# 
+# We'll use cargo-chef to speed up the build
+# 
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+WORKDIR /app
 
-COPY dist/reth /usr/local/bin
+# Install system dependencies
+RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
 
+# 
+# We prepare the build plan
+# 
+FROM chef AS planner
+
+ARG CARGO_BIN
+
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json --bin ${CARGO_BIN}
+
+# 
+# And build the app
+# 
+FROM chef AS builder
+WORKDIR /app
+
+ARG CARGO_BIN
+ARG BUILD_PROFILE=hivetests
+ARG FEATURES=""
+ARG MANIFEST_PATH=""
+
+COPY --from=planner /app/recipe.json recipe.json
+
+RUN cargo chef cook \
+    --profile $BUILD_PROFILE \
+    --features "$FEATURES" \
+    ${MANIFEST_PATH:+"--manifest-path $MANIFEST_PATH"} \
+    --recipe-path recipe.json \
+    --locked
+
+COPY . .
+RUN cargo build --profile $BUILD_PROFILE --features "$FEATURES" --locked --bin $CARGO_BIN
+
+# 
+# The runtime will then just use the build artifact without building anything
+# 
+FROM ubuntu AS runtime
+
+ARG CARGO_BIN
+
+COPY --from=builder /app/target/hivetests/$CARGO_BIN /usr/local/bin/$CARGO_BIN
 COPY LICENSE-* ./
 
 EXPOSE 30303 30303/udp 9001 8545 8546
 ENV RUST_LOG=debug
-ENTRYPOINT ["/usr/local/bin/reth"]
+ENTRYPOINT ["/usr/local/bin/$CARGO_BIN"]

--- a/.github/workflows/prepare-reth.yml
+++ b/.github/workflows/prepare-reth.yml
@@ -37,15 +37,6 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Build reth
-        run: |
-          CARGO_CMD="cargo build --features ${{ inputs.cargo_features }} --profile hivetests --bin ${{ inputs.binary_name }} --locked"
-          if [ -n "${{ inputs.cargo_package }}" ]; then
-            CARGO_CMD="$CARGO_CMD --manifest-path ${{ inputs.cargo_package }}"
-          fi
-          $CARGO_CMD
-          mkdir dist && cp ./target/hivetests/${{ inputs.binary_name }} ./dist/reth
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -56,6 +47,10 @@ jobs:
           file: .github/assets/hive/Dockerfile
           tags: ${{ inputs.image_tag }}
           outputs: type=docker,dest=./artifacts/reth_image.tar
+          build-args: |
+            CARGO_BIN=${{ inputs.binary_name }}
+            MANIFEST_PATH=${{ inputs.cargo_package }}
+            FEATURES=${{ inputs.cargo_features }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ rustc-ice-*
 
 # Book sources should be able to build with the latest version
 book/sources/Cargo.lock
+
+# Cargo chef recipe file
+recipe.json


### PR DESCRIPTION
The docker build for the hive tests is now a bit lacking - it builds the binary outside the container, then just copies it in. Besides fragility, this also means longer buildtimes since the build is not utilizing `cargo-chef`.

This PR modifies the `prepare-reth` workflow and the hive tests `Dockerfile` to improve the speed and stability of the CI builds